### PR TITLE
update labels, various ppu fixes

### DIFF
--- a/MashyMashy.asm
+++ b/MashyMashy.asm
@@ -692,8 +692,18 @@ NotMenuSecondsOption:
   BEQ MenuLogicDone
   LDA #GAME_SCROLL_TO_GAME ; start the game
   STA game_state
-  JSR LoadGameAttribute
+
+  LDA #%00000110   ; disable sprites, disable background, no clipping on left side
+  STA PPU_CTRL_REG2
+
   JSR MoveSpritesOffScreen
+  JSR LoadGameAttribute
+
+  JSR DisplayScreen0
+
+  LDA #%00011110   ; enable sprites, enable background, no clipping on left side
+  STA PPU_CTRL_REG2
+
   JMP MenuLogicDone
 MenuLogicDone:
   RTS

--- a/MashyMashy.asm
+++ b/MashyMashy.asm
@@ -177,13 +177,13 @@ clrmem:
   LDA #$00
   STA $0000, x
   STA $0100, x
-  STA $0200, x
+  STA $0300, x
   STA $0400, x
   STA $0500, x
   STA $0600, x
   STA $0700, x
   LDA #$FE
-  STA $0300, x
+  STA $0200, x
   INX
   BNE clrmem
 

--- a/MashyMashy.asm
+++ b/MashyMashy.asm
@@ -1389,7 +1389,7 @@ P1RateDisplayLoop:
   CPX #$20
   BEQ P1RateDisplayDone ; if we already drew 8 sprites, then skip the 'hide' state
 P1RateHideLoop:
-  LDA #$F8
+  LDA #$FE
   STA $0264, x
   INX
   CPX #$20
@@ -1414,7 +1414,7 @@ P2RateDisplayLoop:
   CPX $20
   BEQ P2RateDisplayDone ; if we already drew 8 sprites, then skip the 'hide' state
 P2RateHideLoop:
-  LDA #$F8
+  LDA #$FE
   STA $0284, x
   INX
   CPX #$20
@@ -1510,7 +1510,7 @@ LoadMashButtonStartLoop:
 
 MoveSpritesOffScreen:
   LDX #$00
-  LDA #$F0                      ; Off screen in Y direction
+  LDA #$FE                      ; Off screen in Y direction
 MoveSpritesOffScreenLoop:
   STA $0200, x                  ; Put all sprites in a Y off screen position
   INX

--- a/MashyMashy.asm
+++ b/MashyMashy.asm
@@ -1385,7 +1385,7 @@ RateDisplaySkipP2:
 P1RateDisplay:
   LDA p1_bp_rate_count
   CMP #$00
-  BEQ P1RateHideLoop
+  BEQ P1RateHideLoopEnter
   ASL A
   ASL A
   STA bp_rate_count_times_4
@@ -1398,6 +1398,9 @@ P1RateDisplayLoop:
   BNE P1RateDisplayLoop
   CPX #$20
   BEQ P1RateDisplayDone ; if we already drew 8 sprites, then skip the 'hide' state
+  JMP P1RateHideLoop
+P1RateHideLoopEnter:
+  LDX #$00
 P1RateHideLoop:
   LDA #$FE
   STA $0264, x
@@ -1410,7 +1413,7 @@ P1RateDisplayDone:
 P2RateDisplay:
   LDA p2_bp_rate_count
   CMP #$00
-  BEQ P2RateHideLoop
+  BEQ P2RateHideLoopEnter
   ASL A
   ASL A
   STA bp_rate_count_times_4
@@ -1423,6 +1426,9 @@ P2RateDisplayLoop:
   BNE P2RateDisplayLoop
   CPX #$20
   BEQ P2RateDisplayDone ; if we already drew 8 sprites, then skip the 'hide' state
+  JMP P2RateHideLoop
+P2RateHideLoopEnter:
+  LDX #$00
 P2RateHideLoop:
   LDA #$FE
   STA $0284, x

--- a/MashyMashy.asm
+++ b/MashyMashy.asm
@@ -209,7 +209,7 @@ InitState:
   LDA #GAME_TITLE ; TODO want states to disagree so that it'll load the first time
   STA prev_game_state
 
-  LDA #%000001100  ; disable sprites, disable background, no clipping on left side
+  LDA #%00000110  ; disable sprites, disable background, no clipping on left side
   STA PPU_CTRL_REG2
 
   JSR LoadMenuBackground
@@ -233,6 +233,11 @@ LoadPalettesLoop:
 ; if compare was equal to 128, keep going down
   JSR LoadMenuAttribute
   JSR LoadTitleAttribute
+
+  LDA #$00
+  STA PPU_SPR_ADDR       ; set the low byte (00) of the RAM address
+  LDA #$02
+  STA PPU_SPR_DMA        ; set the high byte (02) of the RAM address, start the transfer
 
   LDA #%00011110   ; enable sprites, enable background, no clipping on left side
   STA PPU_CTRL_REG2
@@ -362,7 +367,7 @@ LoadTitleAttribute:
   LDX #$00              ; start out at 0
 LoadTitleAttributeLoop:
   LDA title_attribute, x ; normally load data from address (attribute + the value in x)
-  STA PPUDATA           ; write to PPU
+  STA PPU_DATA           ; write to PPU
   INX                   ; X = X + 1
   CPX #$40              ; 64 total bytes necessary to do full screen
   BNE LoadTitleAttributeLoop
@@ -1001,13 +1006,13 @@ QueueGameBackground:
   CMP #$00
   BEQ QueueGameBackgroundDone
 
-  LDA #%000001100  ; disable sprites, disable background, no clipping on left side
+  LDA #%00000110   ; disable sprites, disable background, no clipping on left side
   STA PPU_CTRL_REG2
 
   JSR LoadGameBackgroundRow
   JSR DisplayScreen0 ; don't know why above is changing screen, but this will fix it
 
-  LDA #%000111100  ; enable sprites, enable background, no clipping on left side
+  LDA #%00011110  ; enable sprites, enable background, no clipping on left side
   STA PPU_CTRL_REG2
 QueueGameBackgroundDone:
   RTS

--- a/MashyMashy.asm
+++ b/MashyMashy.asm
@@ -209,6 +209,9 @@ InitState:
   LDA #GAME_TITLE ; TODO want states to disagree so that it'll load the first time
   STA prev_game_state
 
+  LDA #%000001100  ; disable sprites, disable background, no clipping on left side
+  STA PPU_CTRL_REG2
+
   JSR LoadMenuBackground
   JSR LoadTitleBackground
 
@@ -997,8 +1000,15 @@ QueueGameBackground:
   LDA menu_background_needs_loading
   CMP #$00
   BEQ QueueGameBackgroundDone
+
+  LDA #%000001100  ; disable sprites, disable background, no clipping on left side
+  STA PPU_CTRL_REG2
+
   JSR LoadGameBackgroundRow
   JSR DisplayScreen0 ; don't know why above is changing screen, but this will fix it
+
+  LDA #%000111100  ; enable sprites, enable background, no clipping on left side
+  STA PPU_CTRL_REG2
 QueueGameBackgroundDone:
   RTS
 

--- a/MashyMashy.asm
+++ b/MashyMashy.asm
@@ -1421,7 +1421,7 @@ P2RateDisplayLoop:
   INX
   CPX bp_rate_count_times_4 ; 32 -> 8 sprites
   BNE P2RateDisplayLoop
-  CPX $20
+  CPX #$20
   BEQ P2RateDisplayDone ; if we already drew 8 sprites, then skip the 'hide' state
 P2RateHideLoop:
   LDA #$FE


### PR DESCRIPTION
as requested, bug fixes broken out into individual commits.

- update labels for readability - some labels were missing colons, updated some addresses to use labels.

- disable bg and spr rendering during ppu writes - if rendering is enabled during write operations the data will get written to an unintended address resulting in graphical corruption.

- correct address in memory clearing routine - #$FE is written to shadow OAM to ensure sprite slots aren't drawn on the screen if they are unused.  $0200 is being used for shadow OAM.

- push initial sprite state to ppu, bug fixes - pushing the initial sprite state to the ppu before we start rendering should prevent a single frame of random sprites littered on the screen.  also fix a bug in a previous patch involving bitfields.

- move sprites off screen to a consistent position - #$FE should be a consistent position to move sprites off screen, rate bar may still be visible on the y axis on some frames due to the way the loop is written, further investigation needed

-  disable rendering while writing game attributes - add a missed case when writing game attributes, snap the screen back to screen 0 after writing as a tradeoff between seeing screen 1
for a single frame vs a slight vertical misalignment for the same frame.  not perfect, but less intensive than rewriting.

- fix player 2 sprites - sprites for player 2 were flickering because they were comparing an address rather than an immediate value.

- limit rate bars to their intended bounds - in some cases the rate bar code was falling through to clear sprites but writing past their intended bounds corrupting unused wram. (i believe this also fixes the y axis issue i saw after "move sprites to a consistent position" but was present in master)